### PR TITLE
docs: fix simple typo, ancilliary -> ancillary

### DIFF
--- a/linux/src/fping.c
+++ b/linux/src/fping.c
@@ -1794,7 +1794,7 @@ int receive_packet(int socket,
     }
 
 #if HAVE_SO_TIMESTAMP
-    /* ancilliary data */
+    /* ancillary data */
     for (cmsg = CMSG_FIRSTHDR(&recv_msghdr);
          cmsg != NULL;
          cmsg = CMSG_NXTHDR(&recv_msghdr, cmsg)) {


### PR DESCRIPTION
There is a small typo in linux/src/fping.c.

Should read `ancillary` rather than `ancilliary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md