### PR TITLE
防止新版本误判

### DIFF
--- a/shell/cf.sh
+++ b/shell/cf.sh
@@ -312,7 +312,7 @@ done
 	url=$(cat temp.txt | grep url= | cut -f 2- -d'=')
 	app=$(cat temp.txt | grep app= | cut -f 2- -d'=')
 	databasenew=$(cat temp.txt | grep database= | cut -f 2- -d'=')
-	if [ "$app" != "20201208" ]
+	if [ "$app" != "20201208" ] && [ "$app" != "" ]
 	then
 		echo 发现新版本程序: $app
 		echo 更新地址: $url


### PR DESCRIPTION
防止将$app获取失败时的空字符串误判为新版本 https://github.com/badafans/better-cloudflare-ip/blob/517d01d4a9f29b6f445a7841132995d07746c207/shell/cf.sh#L315