### PR TITLE
Fix random_data_flag multi-def compilation error

### DIFF
--- a/linux/src/fping.h
+++ b/linux/src/fping.h
@@ -11,7 +11,7 @@
 void crash_and_burn( char *message );
 void errno_crash_and_burn( char *message );
 int in_cksum( unsigned short *p, int n );
-int random_data_flag;
+extern int random_data_flag;
 
 /* socket.c */
 int  open_ping_socket_ipv4();


### PR DESCRIPTION
The global variable random_data_flag is defined in fping.c, but the forward declaration in fping.h does not have `extern`, so it's also definition.
It's causing compilation error of multiple definition.

gcc -Wall -Wextra -Wno-sign-compare -DIPV6 -g -O2   -o fping fping-fping.o fping-seqmap.o fping-socket4.o fping-optparse.o fping-socket6.o  
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: fping-socket4.o:/home/yao/projects/download/linux/src/fping.h:14: multiple definition of `random_data_flag'; fping-fping.o:/home/yao/projects/download/linux/src/fping.h:14: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: fping-socket6.o:/home/yao/projects/download/linux/src/fping.h:14: multiple definition of `random_data_flag'; fping-fping.o:/home/yao/projects/download/linux/src/fping.h:14: first defined here